### PR TITLE
Fix KeyError: 'name' and OllamaResponse validation error in ollama-bench.py

### DIFF
--- a/ollama-bench.py
+++ b/ollama-bench.py
@@ -223,7 +223,7 @@ def main():
 
     client = ollama.Client(host=host)
     models_data = client.list()
-    available_models = [model['name'] for model in models_data['models']]
+    available_models = [model['model'] for model in models_data['models']]
     print("Available models:")
     for i, model in enumerate(available_models, start=1):
         print(f"{i}. {model}")


### PR DESCRIPTION
While running ollama-bench.py, I encountered two issues that prevented the script from functioning correctly with the latest ollama library. This PR addresses both problems.

1. KeyError: 'name' in Model Listing
> ollama-bench.py:26: PydanticDeprecatedSince20: Pydantic V1 style `@validator` validators are deprecated. You should migrate to Pydantic V2 style `@field_validator` validators, see the migration guide for more details. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.10/migration/
  @validator("prompt_eval_count")
Traceback (most recent call last):
  File "ollama-bench.py", line 302, in <module>
    main()
  File "ollama-bench.py", line 226, in main
    available_models = [model['name'] for model in models_data['models']]
  File "ollama-bench.py", line 226, in <listcomp>
    available_models = [model['name'] for model in models_data['models']]
  File "/usr/local/lib/python3.8/dist-packages/ollama/_types.py", line 32, in __getitem__
    raise KeyError(key)
KeyError: 'name'

The error occurs because line 226 attempts to access the 'name' key in models_data['models'], but the data structure returned by the ollama library uses 'model' instead. I added a debug print to inspect models_data['models'] and found:
> Models data: [Model(model='deepseek-r1:1.5b', modified_at=datetime.datetime(2025, 4, 8, 4, 32, 12, 672068, tzinfo=TzInfo(UTC)), digest='a42b25d8c10a841bd24724309898ae851466696a7d7f3a0a408b895538ccbc96', size=1117322599, details=ModelDetails(parent_model='', format='gguf', family='qwen2', families=['qwen2'], parameter_size='1.8B', quantization_level='Q4_K_M'))]

there is no key named 'name', instead it's named 'model', so I change the key from name to model

2. OllamaResponse validation error, decided to convert `ChatResponse` to a dictionary compatible with `OllamaResponse` if needed
> Request 1: Error occurred for prompt: '"What causes the seasons?",' using model deepseek-r1:1.5b. Error: 1 validation error for OllamaResponse
  Input should be a valid dictionary or instance of OllamaResponse [type=model_type, input_value=ChatResponse(model='deeps...=None, tool_calls=None)), input_type=ChatResponse]
    For further information visit https://errors.pydantic.dev/2.10/v/model_type